### PR TITLE
validates that the table exists in the database

### DIFF
--- a/api/app/database/todo_store.py
+++ b/api/app/database/todo_store.py
@@ -27,8 +27,10 @@ class TodoStore:
     async def setup_db(self) -> Any:
         try:
             self._conn = await r.connect(self._conn_string, self._port)
-            if "todos" not in await r.db_list().run(self._conn):  # setup db and tables
-                await r.db_create("todos").run(self._conn)
+            if db_name not in await r.db_list().run(self._conn):  # setup db and tables
+                await r.db_create(db_name).run(self._conn)
+                await r.db(db_name).table_create(db_table).run(self._conn)
+            elif db_table not in await r.db(db_name).table_list().run(self._conn):
                 await r.db(db_name).table_create(db_table).run(self._conn)
         except ReqlDriverError as err:
             logger.warning(f"Could not connect to DB: {err}")


### PR DESCRIPTION
small change. 

If a table didnt exist in a database when running run.cmd, but the database existed (for whatever reason), the table wasn't recreated.

Also replaced the raw string "todos" with the variable that already existed.